### PR TITLE
ignore non-local files

### DIFF
--- a/autoload/tscompletejob.vim
+++ b/autoload/tscompletejob.vim
@@ -170,6 +170,9 @@ func! tscompletejob#wait_response(id, ...) abort
 endfunc
 
 func! tscompletejob#add_buffer(bufname)
+    if a:bufname =~# '^\w\+://'
+        return
+    endif
     let key = s:bufmgr.addBuffer(a:bufname)
     if (g:tscompletejob_load_on_buf_open)
         call s:ensureReload(s:bufmgr.getFileName(key))


### PR DESCRIPTION
fixes https://github.com/lambdalisue/gina.vim/issues/60 and https://github.com/runoshun/tscompletejob/issues/5. Currently gina break when opening a buffer with filetype typescript and tscompletejob enabled.

@lambdalisue suggested that it is a bug in this plugin and not gina so added a simple fix to ignore if the file is not a local file.